### PR TITLE
add static offset to work with still scenes

### DIFF
--- a/js/webcam-processing.js
+++ b/js/webcam-processing.js
@@ -16,6 +16,11 @@
       transitionUpThreshold   = eWidth - transitionUpRatio,
       transitionDownThreshold = transitionDownRatio,
       myImg = document.getElementById('the-image'),
+      // Amount to offset the pixels every line scan. This makes it seem like
+      // the camera is panning a bit. To turn this off, set both to 0.
+      offset = 0, // Initial offset, gets incremented and reset after offsetLimit is reached
+      offsetLimit = 2, // Effecitively controls the "thickness" of the offset effect
+      //
       imgPixelData;
 
     p.setup = function () {
@@ -69,7 +74,7 @@
 
       for (j = 0; j <= nb; j += 1) {
         for (i = 0; i <= nb; i += 1) {
-          val = p.pixels.getPixel(j * width + i);
+          val = p.pixels.getPixel(j * width + i + offset);
           currentBrightness = p.brightness(val);
           currentSize = cachedDiameter[j][i];
           p.ellipseMode(p.CORNER);
@@ -86,6 +91,10 @@
             cachedBrightness[j][i] = currentBrightness;
             cachedDiameter[j][i] = currentSize;
           }
+        }
+        offset++;
+        if (offset > offsetLimit) {
+          offset = 0;
         }
       }
 


### PR DESCRIPTION
This makes it so that a static scene still draws it's outline basically. Works pretty well:

![screen shot 2015-11-18 at 10 22 07 am](https://cloud.githubusercontent.com/assets/35763/11244930/40b77fb2-8dde-11e5-8ce3-0dbb2c86b659.png)

Thats with me just sitting still in front of it.

That being said it does introduce an artifact: an N pixel column on the left edge due to how it's doing the pixel shifting. This can be looked at a bit more, but this is more of a proof of concept that it can be done.
